### PR TITLE
[QSP-3] removed unlocked pragma

### DIFF
--- a/contracts/InitializableV2.sol
+++ b/contracts/InitializableV2.sol
@@ -1,6 +1,6 @@
 // contracts/InitializableV2.sol
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.7.3;
+pragma solidity 0.7.3;
 
 import "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol";
 

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,6 +1,6 @@
 // contracts/SuperRareToken.sol
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.7.3;
+pragma solidity 0.7.3;
 
 contract Migrations {
     address public owner;

--- a/contracts/claim/SuperRareTokenMerkleDrop.sol
+++ b/contracts/claim/SuperRareTokenMerkleDrop.sol
@@ -1,6 +1,6 @@
 // contracts/claim/SuperRareTokenMerkleDrop.sol
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.7.3;
+pragma solidity 0.7.3;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol";

--- a/contracts/erc20/SuperRareToken.sol
+++ b/contracts/erc20/SuperRareToken.sol
@@ -1,6 +1,6 @@
 // contracts/erc20/SuperRareToken.sol
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.7.3;
+pragma solidity 0.7.3;
 
 import "@openzeppelin/contracts-upgradeable/presets/ERC20PresetMinterPauserUpgradeable.sol";
 import "../InitializableV2.sol";

--- a/contracts/registry/Registry.sol
+++ b/contracts/registry/Registry.sol
@@ -1,6 +1,6 @@
 // contracts/registry/Registry.sol
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.7.3;
+pragma solidity 0.7.3;
 
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/math/SafeMathUpgradeable.sol";


### PR DESCRIPTION
Removed the carrot (^) before the pragma version to "lock" the solidity compiler version